### PR TITLE
Bugfix to allow IC2 addresses which are not integers

### DIFF
--- a/display.js
+++ b/display.js
@@ -69,7 +69,7 @@ exports.initializeLcd = function( config, ctrls ) {
                 cols: config.lcdCols, rows:config.lcdRows } );
             break;
         case 1:
-            var lcdI_address = parseInt( '0x' + config.lcdI2cAddress, 16 );
+            var lcdI_address =  '0x' + config.lcdI2cAddress;
             lcdI = new iLcd( config.lcdI2cBus, lcdI_address, config.lcdCols, config.lcdRows );
             if ( lcdI == null ) {
                 utils.log( 'Error: Unable to initiate hardware LCD panel at address 0x' + 

--- a/public/config.js
+++ b/public/config.js
@@ -551,7 +551,7 @@ function validateConfigData( newData ) {
     newData.lcdCols = parseInt( $( "#cfgLcdColsID" ).val() );
     newData.lcdRows = parseInt( $( "#cfgLcdRowsID" ).val() );
     newData.lcdI2cBus = parseInt( $( "#cfgLcdI2cBusID").val() );
-    newData.lcdI2cAddress = parseInt( $( "#cfgLcdI2cAddressID" ).val() );            
+    newData.lcdI2cAddress = $( "#cfgLcdI2cAddressID" ).val();            
     newData.lcdRsPin = parseInt( $( "#cfgLcdRsPinID" ).val() );
     newData.lcdEPin = parseInt( $( "#cfgLcdEPinID" ).val() );
     newData.lcdBlPin = parseInt( $( "#cfgLcdBLPinID" ).val() );


### PR DESCRIPTION
I was using an IC2 backpack with address 3C, which wouldn't work, as it's not an integer. This is a fix for the relevant issue. 